### PR TITLE
Fix memory overflow issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,8 @@ DD_COUNT = 1
 
 insmod: $(KBUILD_DIR)/fa_sniffer.ko
 	sudo sh -c 'echo 7 >/proc/sys/kernel/printk'
-	cp $^ /tmp
 	lsmod | grep -q fa_sniffer && sudo /sbin/rmmod fa_sniffer; true
-	sudo /sbin/insmod /tmp/fa_sniffer.ko
+	sudo /sbin/insmod $^
 
 rmmod:
 	sudo /sbin/rmmod fa_sniffer.ko

--- a/fa_sniffer.c
+++ b/fa_sniffer.c
@@ -67,12 +67,6 @@ module_param(fa_buffer_count, int, S_IRUGO);
 module_param(fa_entry_count, int, S_IRUGO);
 
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,8,0)
-#define __devinit
-#define __devexit
-#endif
-
-
 /* If test is true then do on_error, print message and goto target. */
 #define TEST_(test, on_error, target, message) \
     do if (test) { \
@@ -1154,7 +1148,7 @@ static void fa_sniffer_disable(struct pci_dev *pdev, bool is_spec_board)
 }
 
 
-static int __devinit fa_sniffer_probe(
+static int fa_sniffer_probe(
     struct pci_dev *pdev, const struct pci_device_id *id)
 {
     unsigned int minor;
@@ -1221,7 +1215,7 @@ no_minor:
 }
 
 
-static void __devexit fa_sniffer_remove(struct pci_dev *pdev)
+static void fa_sniffer_remove(struct pci_dev *pdev)
 {
     struct fa_sniffer *fa_sniffer = pci_get_drvdata(pdev);
     unsigned int minor = MINOR(fa_sniffer->cdev.dev);

--- a/fa_sniffer.c
+++ b/fa_sniffer.c
@@ -654,7 +654,7 @@ static int fa_sniffer_open(struct inode *inode, struct file *file)
         return -EBUSY;
 
     int rc = 0;
-    struct fa_sniffer_open *open = kmalloc(sizeof(*open), GFP_KERNEL);
+    struct fa_sniffer_open *open = kmalloc(sizeof(struct fa_sniffer_open), GFP_KERNEL);
     TEST_PTR(rc, open, no_open, "Unable to allocate open structure");
     file->private_data = open;
 
@@ -1160,7 +1160,7 @@ static int fa_sniffer_probe(
     if (rc < 0)     goto no_sniffer;
 
     struct fa_sniffer *fa_sniffer = kmalloc(
-        sizeof(*fa_sniffer) + fa_buffer_count * sizeof(struct fa_block),
+        sizeof(struct fa_sniffer) + fa_buffer_count * sizeof(struct fa_block),
         GFP_KERNEL);
     TEST_PTR(rc, fa_sniffer, no_memory, "Unable to allocate memory");
 

--- a/fa_sniffer.c
+++ b/fa_sniffer.c
@@ -247,7 +247,7 @@ static int initialise_fa_hw(
     struct pci_dev *pdev, struct fa_sniffer_hw **hw, bool is_spec_board)
 {
     int rc = 0;
-    *hw = kmalloc(sizeof(*hw), GFP_KERNEL);
+    *hw = kmalloc(sizeof(struct fa_sniffer_hw), GFP_KERNEL);
     TEST_PTR(rc, *hw, no_hw, "Cannot allocate fa hardware");
 
     struct x5pcie_dma_registers *regs =


### PR DESCRIPTION
In summary, the driver worked in RHEL6 because we were lucky to not smash any important memory (with the risk of having random stability issues).
We were allocating 8 bytes for the `fa_sniffer_hw` structure when we actually needed 24 bytes.
I have tested that this fixed the problem successfully.